### PR TITLE
Devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# emacs backup files
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,23 +36,23 @@ find_package (gclib REQUIRED)
 include_directories (${gclib_INCLUDE_DIR})
 link_directories (${gclib_LIBRARY_DIR})
 
-if (NOT WIN32)
-    set (catkin_REQUIRED_COMPONENTS
-         roscpp
-         rospy
-         std_msgs
-         geometry_msgs
-         cisst_msgs
-         cisst_ros_bridge)
+set (catkin_REQUIRED_COMPONENTS
+     roscpp
+     rospy
+     std_msgs
+     geometry_msgs
+     cisst_msgs
+     cisst_ros_bridge)
 
-    find_package(catkin REQUIRED COMPONENTS ${catkin_REQUIRED_COMPONENTS})
+find_package(catkin COMPONENTS ${catkin_REQUIRED_COMPONENTS})
+
+if (catkin_FOUND)
     include_directories(${catkin_INCLUDE_DIRS})
 
     catkin_package(
         INCLUDE_DIRS include
         LIBRARIES sawGalilController
         CATKIN_DEPENDS ${catkin_REQUIRED_COMPONENTS})
-
 endif ()
 
 if (cisst_FOUND_AS_REQUIRED)
@@ -73,7 +73,7 @@ if (cisst_FOUND_AS_REQUIRED)
     # catkin/ROS paths
     cisst_set_output_path ()
 
-    if (NOT WIN32)
+    if (catkin_FOUND)
         catkin_package(
             LIBRARIES sawGalilController
             INCLUDE_DIRS include
@@ -116,7 +116,7 @@ if (cisst_FOUND_AS_REQUIRED)
             ARCHIVE DESTINATION lib
     )
 
-    if (NOT WIN32)
+    if (catkin_FOUND)
         install(TARGETS sawGalilController
             ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
             LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,6 @@ project (sawGalilController VERSION 0.1.0)
 
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set (sawGalilController_INCLUDE_DIR "${sawGalilController_SOURCE_DIR}/include")
-include_directories (${sawGalilController_INCLUDE_DIR})
-
 add_subdirectory (share)
 
 # create a list of required cisst libraries
@@ -57,12 +54,6 @@ endif ()
 
 if (cisst_FOUND_AS_REQUIRED)
 
-    set (sawGalilController_HEADER_FILES
-         "${sawGalilController_INCLUDE_DIR}/sawGalilController/mtsGalilController.h"
-         "${sawGalilController_INCLUDE_DIR}/sawGalilController/sawGalilControllerExport.h")
-    set (sawGalilController_SOURCE_FILES
-         code/mtsGalilController.cpp)
-
     # load cisst configuration
     include (${CISST_USE_FILE})
 
@@ -70,8 +61,15 @@ if (cisst_FOUND_AS_REQUIRED)
         message( FATAL_ERROR "sawGalilController requires cisst to be built with JSON" )
     endif ()
 
+    # Default library path
+    set (LIBRARY_OUTPUT_PATH "${sawGalilController_BINARY_DIR}/lib")
     # catkin/ROS paths
     cisst_set_output_path ()
+
+    set (sawGalilController_INCLUDE_DIR "${sawGalilController_SOURCE_DIR}/include")
+    include_directories (${sawGalilController_INCLUDE_DIR})
+    set (sawGalilController_LIBRARY_DIR "${LIBRARY_OUTPUT_PATH}")
+    set (sawGalilController_LIBRARIES sawGalilController)
 
     if (catkin_FOUND)
         catkin_package(
@@ -79,11 +77,17 @@ if (cisst_FOUND_AS_REQUIRED)
             INCLUDE_DIRS include
             CATKIN_DEPENDS ${catkin_REQUIRED_COMPONENTS}
         )
-
-        # add all config files for this component
-        cisst_add_config_files (sawGalilController)
     endif ()
     
+    set (sawGalilController_HEADER_FILES
+         "${sawGalilController_INCLUDE_DIR}/sawGalilController/mtsGalilController.h"
+         "${sawGalilController_INCLUDE_DIR}/sawGalilController/sawGalilControllerExport.h")
+    set (sawGalilController_SOURCE_FILES
+         code/mtsGalilController.cpp)
+
+   # add all config files for this component
+   cisst_add_config_files (sawGalilController)
+
    add_library (sawGalilController ${IS_SHARED}
                 ${sawGalilController_HEADER_FILES}
                 ${sawGalilController_SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,11 @@ if (cisst_FOUND_AS_REQUIRED)
     
     set (sawGalilController_HEADER_FILES
          "${sawGalilController_INCLUDE_DIR}/sawGalilController/mtsGalilController.h"
+         "${sawGalilController_INCLUDE_DIR}/sawGalilController/mtsGalilControllerDR.h"
          "${sawGalilController_INCLUDE_DIR}/sawGalilController/sawGalilControllerExport.h")
     set (sawGalilController_SOURCE_FILES
-         code/mtsGalilController.cpp)
+         code/mtsGalilController.cpp
+         code/mtsGalilControllerDR.cpp)
 
    # add all config files for this component
    cisst_add_config_files (sawGalilController)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# (C) Copyright 2016-2023 Johns Hopkins University (JHU), All Rights Reserved.
+# (C) Copyright 2016-2024 Johns Hopkins University (JHU), All Rights Reserved.
 #
 # --- begin cisst license - do not edit ---
 #
@@ -10,9 +10,12 @@
 # --- end cisst license ---
 
 cmake_minimum_required (VERSION 3.10)
-project (mts_galil_controller VERSION 0.0.0)
+project (sawGalilController VERSION 0.1.0)
 
-include_directories (include)
+set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set (sawGalilController_INCLUDE_DIR "${sawGalilController_SOURCE_DIR}/include")
+include_directories (${sawGalilController_INCLUDE_DIR})
 
 add_subdirectory (share)
 
@@ -27,97 +30,103 @@ set (REQUIRED_CISST_LIBRARIES
 
 find_package (cisst 1.2.0 REQUIRED ${REQUIRED_CISST_LIBRARIES})
 
-set( catkin_REQUIRED_COMPONENTS 
-    roscpp
-    rospy
-    std_msgs
-    geometry_msgs
-    cisst_msgs
-    cisst_ros_bridge
-)
+# Find Galil gclib
+find_package (gclib REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS
-    ${catkin_REQUIRED_COMPONENTS}
-)
-include_directories(${catkin_INCLUDE_DIRS})
-catkin_package(
-    INCLUDE_DIRS include
-    LIBRARIES mtsGalilController
-    CATKIN_DEPENDS ${catkin_REQUIRED_COMPONENTS}
-)
+include_directories (${gclib_INCLUDE_DIR})
+link_directories (${gclib_LIBRARY_DIR})
 
-set ( mtsGalilController_HEADER_FILES
-    include/mtsGalilController/mtsGalilController.h
-)
-set ( mtsGalilController_SOURCE_FILES
-    code/mtsGalilController.cpp
-)
+if (NOT WIN32)
+    set (catkin_REQUIRED_COMPONENTS
+         roscpp
+         rospy
+         std_msgs
+         geometry_msgs
+         cisst_msgs
+         cisst_ros_bridge)
+
+    find_package(catkin REQUIRED COMPONENTS ${catkin_REQUIRED_COMPONENTS})
+    include_directories(${catkin_INCLUDE_DIRS})
+
+    catkin_package(
+        INCLUDE_DIRS include
+        LIBRARIES sawGalilController
+        CATKIN_DEPENDS ${catkin_REQUIRED_COMPONENTS})
+
+endif ()
 
 if (cisst_FOUND_AS_REQUIRED)
+
+    set (sawGalilController_HEADER_FILES
+         "${sawGalilController_INCLUDE_DIR}/sawGalilController/mtsGalilController.h"
+         "${sawGalilController_INCLUDE_DIR}/sawGalilController/sawGalilControllerExport.h")
+    set (sawGalilController_SOURCE_FILES
+         code/mtsGalilController.cpp)
 
     # load cisst configuration
     include (${CISST_USE_FILE})
 
     if (NOT CISST_HAS_JSON)
-        message( FATAL_ERROR "mtsGalilController requires cisst to be built with JSON" )
+        message( FATAL_ERROR "sawGalilController requires cisst to be built with JSON" )
     endif ()
 
     # catkin/ROS paths
     cisst_set_output_path ()
-    catkin_package(
-        LIBRARIES mtsGalilController
-        INCLUDE_DIRS include
-        CATKIN_DEPENDS ${catkin_REQUIRED_COMPONENTS}
-    )
 
-    # add all config files for this component
-    cisst_add_config_files (mtsGalilController)
+    if (NOT WIN32)
+        catkin_package(
+            LIBRARIES sawGalilController
+            INCLUDE_DIRS include
+            CATKIN_DEPENDS ${catkin_REQUIRED_COMPONENTS}
+        )
+
+        # add all config files for this component
+        cisst_add_config_files (sawGalilController)
+    endif ()
     
-    add_library (mtsGalilController 
-        ${mtsGalilController_SOURCE_FILES}
-    )
+   add_library (sawGalilController ${IS_SHARED}
+                ${sawGalilController_HEADER_FILES}
+                ${sawGalilController_SOURCE_FILES})
     
-    cisst_target_link_libraries (mtsGalilController ${REQUIRED_CISST_LIBRARIES})
+    cisst_target_link_libraries (sawGalilController ${REQUIRED_CISST_LIBRARIES})
     
-    set_target_properties (mtsGalilController PROPERTIES
-        VERSION ${mts_galil_controller_VERSION}
-        FOLDER "mtsGalilController"
-        PUBLIC_HEADER "${mtsGalilController_HEADER_FILES}"
-    )
-    target_include_directories(mtsGalilController PUBLIC 
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
-    target_link_libraries (mtsGalilController
-        ${catkin_LIBRARIES}
-        -lgclib
-        -lgclibo                  
-    )
+    set_target_properties (sawGalilController PROPERTIES
+        VERSION ${sawGalilController_VERSION}
+        FOLDER "sawGalilController"
+        PUBLIC_HEADER "${sawGalilController_HEADER_FILES}")
+
+    target_include_directories(sawGalilController PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+    target_link_libraries (sawGalilController ${gclib_LIBRARIES})
 
     # Install target for headers and library
     install (
-        DIRECTORY "${mts_galil_controller_SOURCE_DIR}/include/mtsGalilController"
+        DIRECTORY "${sawGalilController_SOURCE_DIR}/include/sawGalilController"
         DESTINATION include
-        COMPONENT mtsGalilController-dev
+        COMPONENT sawGalilController-dev
         PATTERN .svn EXCLUDE
     )
 
     install (
-        TARGETS mtsGalilController 
-        COMPONENT mtsGalilController
+        TARGETS sawGalilController 
+        COMPONENT sawGalilController
             RUNTIME DESTINATION bin
             LIBRARY DESTINATION lib
             ARCHIVE DESTINATION lib
     )
 
-    install(TARGETS mtsGalilController
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-    )
+    if (NOT WIN32)
+        install(TARGETS sawGalilController
+            ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+            RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        )
 
-    install(DIRECTORY include/mtsGalilController/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-    )
+        install(DIRECTORY include/sawGalilController/
+            DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        )
+    endif ()
 
 else (cisst_FOUND_AS_REQUIRED)
     message ("Information: code in ${CMAKE_CURRENT_SOURCE_DIR} will not be compiled, it requires ${REQUIRED_CISST_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ if (cisst_FOUND_AS_REQUIRED)
         )
     endif ()
 
+    add_subdirectory (examples)
+
 else (cisst_FOUND_AS_REQUIRED)
     message ("Information: code in ${CMAKE_CURRENT_SOURCE_DIR} will not be compiled, it requires ${REQUIRED_CISST_LIBRARIES}")
 endif (cisst_FOUND_AS_REQUIRED)

--- a/cmake/Findgclib.cmake
+++ b/cmake/Findgclib.cmake
@@ -1,0 +1,63 @@
+# (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+#
+# --- begin cisst license - do not edit ---
+#
+# This software is provided "as is" under an open source license, with
+# no warranty.  The complete license can be found in license.txt and
+# http://www.cisst.org/cisst/license.txt.
+#
+# --- end cisst license ---
+
+# Findgclib
+#
+# Find the Galil Controller Library (gclib). It is sufficient to set gclib_INCLUDE_DIR
+# because the other files should then be found automatically.
+#
+#    gclib_ROOT            -- root directory for library
+#    gclib_INCLUDE_DIR     -- path to header files
+#    gclib_LIBRARY_DIR     -- path to library files
+#    gclib_LIBRARIES       -- list of library names
+#    gclib_FOUND           -- true if package found
+#
+# Also sets the following:
+#    gclib_LIBRARY_gclib   -- full path to gclib library
+#    gclib_LIBRARY_gclibo  -- full path to gclibo library
+
+set (gclib_FOUND FALSE)
+set (gclib_LIBRARIES "")
+
+find_path (gclib_INCLUDE_DIR NAMES gclib.h
+           DOC "Directory for gclib header files")
+
+if (gclib_INCLUDE_DIR)
+  get_filename_component(gclib_ROOT ${gclib_INCLUDE_DIR} DIRECTORY)
+
+  # Determine whether to look for 32-bit or 64-bit libraries
+  if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(gclib_ARCH "64")
+  else ()
+    set(gclib_ARCH "32")
+  endif ()
+
+  find_library (gclib_LIBRARY_GCLIB  NAMES gclib
+                DOC "Galil gclib library"
+                HINTS "${gclib_ROOT}/lib"
+		PATH_SUFFIXES "dynamic/x${gclib_ARCH}")
+
+  if (gclib_LIBRARY_GCLIB)
+    get_filename_component(gclib_NAME_GCLIB ${gclib_LIBRARY_GCLIB} NAME)
+    set (gclib_LIBRARIES ${gclib_LIBRARIES} ${gclib_NAME_GCLIB})
+    unset (gclib_NAME_GCLIB)
+    get_filename_component(gclib_LIBRARY_DIR ${gclib_LIBRARY_GCLIB} DIRECTORY)
+
+    find_library (gclib_LIBRARY_GCLIBO NAMES gclibo
+                  DOC "Galil gclibo library"
+                  PATHS ${gclib_LIBRARY_DIR})
+    if (gclib_LIBRARY_GCLIBO)
+      get_filename_component(gclib_NAME_GCLIBO ${gclib_LIBRARY_GCLIBO} NAME)
+      set (gclib_LIBRARIES ${gclib_LIBRARIES} ${gclib_NAME_GCLIBO})
+      unset (gclib_NAME_GCLIBO)
+      set (gclib_FOUND TRUE)
+    endif ()
+  endif ()
+endif ()

--- a/code/mtsGalilController.cpp
+++ b/code/mtsGalilController.cpp
@@ -290,7 +290,7 @@ void mtsGalilController::Cleanup(){
         Close();
         CMN_LOG_CLASS_RUN_VERBOSE << "Closed Galil Controller." << std::endl;
     }
-    catch (std::runtime_error e)
+    catch (const std::runtime_error &e)
     {
         throw e;
     }
@@ -335,7 +335,8 @@ void mtsGalilController::Close()
         SendCommandString("ST");
         DisableAllMotorPower();
         GClose(m_Galil);
-        delete m_Galil;
+        // PK: I do not think it is necessary or correct to delete m_Galil
+        // delete m_Galil;
     }
 }
 
@@ -363,18 +364,15 @@ void mtsGalilController::ConnectToGalilController(const std::string &deviceName)
 
         CMN_LOG_CLASS_INIT_VERBOSE << "Galil Servo Loop Time is " << m_ServoLoopTime / 1000.0 << " ms" << std::endl;
     }
-    catch (std::string e) // error
+    catch (const std::string &e) // error
     {
         CMN_LOG_CLASS_INIT_ERROR << e << std::endl;
         if (std::string::npos != e.find("COMMAND ERROR"))
             CMN_LOG_CLASS_INIT_ERROR << "a command error occurred" << std::endl; // special processing for command errors
-
-        return;
     }
-    catch (std::runtime_error e) // error
+    catch (const std::runtime_error &e) // error
     {
         CMN_LOG_CLASS_RUN_ERROR << e.what() << std::endl;
-        return;
     }
     return;
 }
@@ -388,7 +386,7 @@ void mtsGalilController::EnableAllMotorPower()
     {
         this->SendCommandString("SH");
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Enable motor failed  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("Enable motor failed "));
@@ -405,7 +403,7 @@ void mtsGalilController::DisableAllMotorPower()
         this->StopMotionAll();
         SendCommandString("MO");
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Disable motor failed  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("Disable motor failed "));
@@ -421,7 +419,7 @@ void mtsGalilController::EnableMotorPower(const mtsBoolVec &mask)
         CreateCommandForAxis(buffer, "SH", mask);
         SendCommandString(buffer);
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Enable motor failed  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("Enable motor failed "));
@@ -439,7 +437,7 @@ void mtsGalilController::DisableMotorPower(const mtsBoolVec &mask)
         CreateCommandForAxis(buffer, "MO", mask);
         SendCommandString(buffer);
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Disable motor Failed  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("Disable motor Failed "));
@@ -456,7 +454,7 @@ void mtsGalilController::StopMotionAll()
         all.SetAll(true);
         StopMotion(all);
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Stop Motion failed  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("Stop Motion error "));
@@ -481,7 +479,7 @@ void mtsGalilController::StopMotion(const mtsBoolVec &mask)
             SendCommandString(buffer);
         }
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Stop Motion failed  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("Stop Motion  error "));
@@ -523,12 +521,12 @@ void mtsGalilController::Home(const mtsBoolVec &mask)
         SendCommandString(buffer);
     }
 
-    catch (std::runtime_error e)
+    catch (const std::runtime_error &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Homing failed: Error  \"" << e.what() << "\"" << std::endl;
         cmnThrow(std::runtime_error("Homing error "));
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Homing failed: Error  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("Homing error "));
@@ -551,7 +549,7 @@ void mtsGalilController::UnHome(const mtsBoolVec &mask)
         CreateCommand(buffer, "ZA", mask, homeValue);
         SendCommandString(buffer);
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "UnHoming failed: Error  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("UnHoming error "));
@@ -737,7 +735,7 @@ void mtsGalilController::GetActuatorState(prmActuatorState &state)
         // 21 Begin not valid while running 100 Not valid when running ECAM
         // 22 Begin not possible due to Limit Switch 101 Improper index into ET (must be 0-256)
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "GetActuatorState: Error  \"" << e << "\"" << std::endl;
         cmnThrow(std::runtime_error("GetActuatorState: Error "));
@@ -914,7 +912,7 @@ void mtsGalilController::StopMovement(const mtsBoolVec &mask, double timeout)
     {
         this->WaitMotion(mask, timeout);
     }
-    catch (std::runtime_error e)
+    catch (const std::runtime_error &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Stop movement failed: " << e.what() << std::endl;
         cmnThrow(std::runtime_error(std::string("Stop movement failed with error") + e.what()));
@@ -956,7 +954,7 @@ void mtsGalilController::WaitMotion(const mtsBoolVec &mask, double timeout)
         if (timer.GetElapsedTime() > timeout)
             cmnThrow(std::runtime_error(std::string("Timeout reached:")));
     }
-    catch (std::string e)
+    catch (const std::string &e)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Wait for Motion failed: " << e << std::endl;
         cmnThrow(std::runtime_error(std::string("Wait for motion error") + e));
@@ -984,7 +982,7 @@ std::string mtsGalilController::SendCommandString(const std::string &cmd)
 
         response = BufferToGCStringOut(buffer, G_SMALL_BUFFER);
     }
-    catch (GReturn rc)
+    catch (const GReturn &rc)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Error for command \\" << cmd << "\\" << std::endl;
         CMN_LOG_CLASS_RUN_ERROR << "Galil error code: " << rc << std::endl;
@@ -1022,7 +1020,7 @@ int mtsGalilController::SendCommandInt(const std::string &cmd)
         CheckErrorGCommand(
             GCmdI(m_Galil, cmd.c_str(), &response));
     }
-    catch (GReturn rc)
+    catch (const GReturn &rc)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Error for command \\" << cmd << "\\" << std::endl;
         CMN_LOG_CLASS_RUN_ERROR << "Galil error code: " << rc << std::endl;
@@ -1061,7 +1059,7 @@ double mtsGalilController::SendCommandDouble(const std::string &cmd)
         CheckErrorGCommand(
             GCmdD(m_Galil, cmd.c_str(), &response));
     }
-    catch (GReturn rc)
+    catch (const GReturn &rc)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Error for command \\" << cmd << "\\" << std::endl;
         CMN_LOG_CLASS_RUN_ERROR << "Galil error code: " << rc << std::endl;

--- a/code/mtsGalilController.cpp
+++ b/code/mtsGalilController.cpp
@@ -13,9 +13,6 @@ http://www.cisst.org/cisst/license.txt.
 --- end cisst license ---
 */
 
-#include <gclib.h>
-#include <gclibo.h>
-
 #include <cisstCommon/cmnDataFormat.h>
 #include <cisstCommon/cmnUnits.h>
 #include <cisstCommon/cmnPath.h>
@@ -95,9 +92,11 @@ void mtsGalilController::Configure(const std::string& fileName)
                                    << "<----" << std::endl;
 
         m_DeviceName = jsonConfig["IP_Address"].asString();
-
         // Configure the axes
         Json::Value axesConfig = jsonConfig["Axes"];
+        m_EncoderCountsPerUnit.SetSize(axesConfig.size());
+        m_AxisToGalilChannelMappings.SetSize(axesConfig.size());
+        m_GalilToAxisChannelMappings.SetSize(axesConfig.size());
         for (auto it = axesConfig.begin(); it != axesConfig.end(); it++)
         {
             unsigned int axisIndex = it.index();
@@ -154,8 +153,9 @@ void mtsGalilController::Configure(const std::string& fileName)
     m_AnalogInput.SetSize(GetNumberActuators());
     m_AnalogInput.Zeros();
 
-    m_EncoderCountsPerUnit.SetSize(GetNumberActuators());
-    m_EncoderCountsPerUnit.SetAll(1.0); // default to use encoder counts
+    // PK: size set above
+    // m_EncoderCountsPerUnit.SetSize(GetNumberActuators());
+    // m_EncoderCountsPerUnit.SetAll(1.0); // default to use encoder counts
 
     // Disha- encoder
     unsigned int Encoder_pins[] = {9, 12, 15, 11, 14, 10, 13, 8, 1, 2};
@@ -213,7 +213,7 @@ void mtsGalilController::SetupInterfaces()
     m_StateTable.AddData(m_ActuatorState, "ActuatorState");
 
     // Add the interface
-    mtsInterfaceProvided* intfProvided = this->AddInterfaceProvided("GalilController");
+    mtsInterfaceProvided* intfProvided = this->AddInterfaceProvided("control");
     if (!intfProvided)
     {
         CMN_LOG_CLASS_INIT_ERROR << "Error adding \"GalilController\" provided interface \"" 
@@ -1024,7 +1024,7 @@ int mtsGalilController::SendCommandInt(const std::string &cmd)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Error for command \\" << cmd << "\\" << std::endl;
         CMN_LOG_CLASS_RUN_ERROR << "Galil error code: " << rc << std::endl;
-        cmnThrow(std::runtime_error(std::string("SendCommand:  Error sending command--") + std::to_string(rc)), CMN_LOG_LOD_RUN_ERROR);
+        cmnThrow(std::runtime_error(std::string("SendCommandInt:  Error sending command--") + std::to_string(rc)), CMN_LOG_LOD_RUN_ERROR);
 
         //  int t = atoi( (e.substr(0,1)).c_str() ); // get int for type, first digit of code
         //  int f = atoi( (e.substr(1,2)).c_str() ); // int for function, middle two digits of code
@@ -1049,7 +1049,7 @@ double mtsGalilController::SendCommandDouble(const std::string &cmd)
     double response;
     if (!m_Galil)
     {
-        cmnThrow(std::runtime_error("SendCommandInt: ( No Controller Handle = Not Connected )"));
+        cmnThrow(std::runtime_error("SendCommandDouble: ( No Controller Handle = Not Connected )"));
     }
     CMN_LOG_CLASS_RUN_DEBUG << "Sending to Galil [" << cmd << "]" << std::endl;
 
@@ -1062,7 +1062,7 @@ double mtsGalilController::SendCommandDouble(const std::string &cmd)
     {
         CMN_LOG_CLASS_RUN_ERROR << "Error for command \\" << cmd << "\\" << std::endl;
         CMN_LOG_CLASS_RUN_ERROR << "Galil error code: " << rc << std::endl;
-        cmnThrow(std::runtime_error(std::string("SendCommand:  Error sending command--") + std::to_string(rc)), CMN_LOG_LOD_RUN_ERROR);
+        cmnThrow(std::runtime_error(std::string("SendCommandDouble:  Error sending command--") + std::to_string(rc)), CMN_LOG_LOD_RUN_ERROR);
 
         //  int t = atoi( (e.substr(0,1)).c_str() ); // get int for type, first digit of code
         //  int f = atoi( (e.substr(1,2)).c_str() ); // int for function, middle two digits of code

--- a/code/mtsGalilController.cpp
+++ b/code/mtsGalilController.cpp
@@ -602,7 +602,7 @@ void mtsGalilController::GetActuatorState(prmActuatorState &state)
         m_DecPosition = 0;
         for (unsigned int i = 0; i < m_NumberEncoderPins; i++)
         {
-            m_DigitalInput[i] = this->SendCommandInt("MG_" + DI[i]);
+            m_DigitalInput[i] = this->SendCommandInt("MG " + DI[i]);
             m_DigitalInput[i] = !m_DigitalInput[i];
 
             m_DecPosition += m_DigitalInput[i] * pow(2, (9 - i));
@@ -620,7 +620,7 @@ void mtsGalilController::GetActuatorState(prmActuatorState &state)
         for (unsigned int i = 0; i < GetNumberActuators(); i++)
         {
             // the encoders are in long
-            state.Position()[i] = (long)this->SendCommandInt("MG_" + TP[i]);
+            state.Position()[i] = (long)this->SendCommandInt("MG " + TP[i]);
 
             // In the new version: This only applies to setting values, e.g., sp.
             // velocity still returns the actual Velocity * (TM/1000) so multiply it by 1000/tm
@@ -629,42 +629,42 @@ void mtsGalilController::GetActuatorState(prmActuatorState &state)
             // this might be different for TMi250, not sure what the value will be
             // it might be 1/4 of actual velocity due to faster sampling
 
-            state.Velocity()[i] = this->SendCommandDouble("MG_" + TV[i]) * m_TMVelocityMultiplier;
+            state.Velocity()[i] = this->SendCommandDouble("MG " + TV[i]) * m_TMVelocityMultiplier;
 
             // analog inputs are not part of the actuator state??
-            m_AnalogInput[i] = this->SendCommandDouble("MG_" + AN[i]);
+            m_AnalogInput[i] = this->SendCommandDouble("MG " + AN[i]);
 
             // be careful, this is a motion profile variable not actual motion (there is a lag where the servo loop
             // catches up to the profile position)
             //  state.Velocity()[i]=(galil->sourceValue(m_data, TV[i]));
-            if (this->SendCommandDouble("MG _" + BG[i]) != 0.0)
+            if (this->SendCommandDouble("MG " + BG[i]) != 0.0)
             {
                 state.InMotion()[i] = true;
             }
 
             // motor off
-            if (this->SendCommandDouble("MG _" + MO[i]) != 0.0)
+            if (this->SendCommandDouble("MG " + MO[i]) != 0.0)
             {
                 state.MotorOff()[i] = true;
             }
 
-            if (this->SendCommandDouble("MG _" + ZA[i]) != 0.0)
+            if (this->SendCommandDouble("MG " + ZA[i]) != 0.0)
             {
                 state.IsHomed()[i] = true;
             }
 
             // TODO: double check the active ihigh/low configuration
             // here we assume that homeCFG=-1
-            if (this->SendCommandDouble("MG _" + HM[i]) != 0.0)
+            if (this->SendCommandDouble("MG " + HM[i]) != 0.0)
                 state.HomeSwitchOn()[i] = true;
 
             // Decelerating or stopped by FWD limit switch OR soft limit FL
-            if (this->SendCommandDouble("MG _" + SC[i]) == 2)
+            if (this->SendCommandDouble("MG " + SC[i]) == 2)
             {
                 state.SoftFwdLimitHit()[i] = true;
                 m_SoftFwdLimitHit = true;
             }
-            if (this->SendCommandDouble("MG _" + SC[i]) == 3)
+            if (this->SendCommandDouble("MG " + SC[i]) == 3)
             {
                 state.SoftRevLimitHit()[i] = true;
                 m_SoftRevLimitHit = true;
@@ -689,18 +689,18 @@ void mtsGalilController::GetActuatorState(prmActuatorState &state)
 
             // TODO: check, this might be differnt for CN-1, or CN1
 
-            if (this->SendCommandDouble("MG _" + LF[i]) == 0)
+            if (this->SendCommandDouble("MG " + LF[i]) == 0)
             {
                 state.HardFwdLimitHit()[i] = true;
             }
 
-            if (this->SendCommandDouble("MG _" + LR[i]) == 0)
+            if (this->SendCommandDouble("MG " + LR[i]) == 0)
             {
                 state.HardFwdLimitHit()[i] = true;
             }
 
             // user variable used to store state of home
-            if (this->SendCommandDouble("MG _" + ZA[i]) == 1)
+            if (this->SendCommandDouble("MG " + ZA[i]) == 1)
             {
                 state.IsHomed()[i] = true;
             }
@@ -726,7 +726,7 @@ void mtsGalilController::GetActuatorState(prmActuatorState &state)
         // the update rate (TM command) will actually set an update rate of 976 microseconds. Thus the
         // value returned by the TIME operand will be off by 2.4% of the actual time.
 
-        state.Timestamp() = this->SendCommandDouble("TIME");
+        state.Timestamp() = this->SendCommandDouble("MG TIME");
 
         // TC is the error code;
         // 1 Unrecognized command 56 Array index invalid or out of range

--- a/code/mtsGalilController.cpp
+++ b/code/mtsGalilController.cpp
@@ -265,12 +265,13 @@ void mtsGalilController::SetupInterfaces()
 
     MTS_ADD_COMMAND_READ_CHECK(intfProvided, &mtsGalilController::GetAnalogInputs, this, "GetAnalogInputs");
 
-    delete intfProvided;
+    // PK: not correct to delete following
+    //delete intfProvided;
 }
 
 
 void mtsGalilController::Startup(){
-    ConnectToGalilController(m_DeviceName.Data);
+    ConnectToGalilController(m_DeviceName);
 }
 
 
@@ -296,12 +297,12 @@ void mtsGalilController::Cleanup(){
     }
 }
 
-void mtsGalilController::SetTimeout(const mtsDouble& timeout, mtsBool& success){
-    success.Data = false;
+void mtsGalilController::SetTimeout(const double& timeout, bool& success){
+    success = false;
     if (timeout > 0)
     {
-        success.Data = true;
-        m_timeout    = timeout;
+        success = true;
+        m_timeout = timeout;
     }
 }
 
@@ -410,7 +411,7 @@ void mtsGalilController::DisableAllMotorPower()
     }
 }
 
-void mtsGalilController::EnableMotorPower(const mtsBoolVec &mask)
+void mtsGalilController::EnableMotorPower(const vctBoolVec &mask)
 {
     CMN_LOG_CLASS_RUN_VERBOSE << "EnableMotorPower \"" << mask << "\"" << std::endl;
     try
@@ -427,7 +428,7 @@ void mtsGalilController::EnableMotorPower(const mtsBoolVec &mask)
 }
 
 // MO not valid while running, need to issue ST first!!!! annoying.
-void mtsGalilController::DisableMotorPower(const mtsBoolVec &mask)
+void mtsGalilController::DisableMotorPower(const vctBoolVec &mask)
 {
     CMN_LOG_CLASS_RUN_VERBOSE << "DisableMotorPower \"" << mask << "\"" << std::endl;
     try
@@ -450,7 +451,7 @@ void mtsGalilController::StopMotionAll()
     try
     {
         CMN_LOG_CLASS_RUN_VERBOSE << "Stop ALL" << std::endl;
-        mtsBoolVec all(GetNumberActuators());
+        vctBoolVec all(GetNumberActuators());
         all.SetAll(true);
         StopMotion(all);
     }
@@ -461,7 +462,7 @@ void mtsGalilController::StopMotionAll()
     }
 }
 
-void mtsGalilController::StopMotion(const mtsBoolVec &mask)
+void mtsGalilController::StopMotion(const vctBoolVec &mask)
 {
     CMN_LOG_CLASS_RUN_VERBOSE << "Stop \"" << mask << "\"" << std::endl;
 
@@ -492,7 +493,7 @@ void mtsGalilController::StopMotion(const mtsBoolVec &mask)
 // THIS IS A BLOCKING COMMAND!!!!!!!!
 // Start homing with the stage to the negative side of the home switch
 
-void mtsGalilController::Home(const mtsBoolVec &mask)
+void mtsGalilController::Home(const vctBoolVec &mask)
 {
     CMN_LOG_CLASS_RUN_VERBOSE << "Homing \"" << mask << "\"" << std::endl;
 
@@ -513,7 +514,7 @@ void mtsGalilController::Home(const mtsBoolVec &mask)
         WaitMotion(mask, 60);
 
         // if home is found, lets save the status in a variable.
-        mtsDoubleVec homeValue;
+        vctDoubleVec homeValue;
         homeValue.SetSize(mask.size());
         homeValue.SetAll(1);
 
@@ -535,11 +536,11 @@ void mtsGalilController::Home(const mtsBoolVec &mask)
 
 // UnHome:  Unhome the robot.  Besides clearing the IsHomed flag, this function turns off the forward and reverse
 //          software travel limits i.e sets them to +/- 100mm
-void mtsGalilController::UnHome(const mtsBoolVec &mask)
+void mtsGalilController::UnHome(const vctBoolVec &mask)
 {
     CMN_LOG_CLASS_RUN_VERBOSE << "UnHoming \"" << mask << "\"" << std::endl;
 
-    mtsDoubleVec homeValue;
+    vctDoubleVec homeValue;
     homeValue.SetSize(mask.size());
     homeValue.SetAll(0);
 
@@ -746,7 +747,7 @@ void mtsGalilController::GetActuatorState(prmActuatorState &state)
     state.Velocity() = ConvertEncoderCountsToAxisUnit(state.Velocity());
 }
 
-void mtsGalilController::GetAnalogInputs(mtsDoubleVec &ain) const
+void mtsGalilController::GetAnalogInputs(vctDoubleVec &ain) const
 {
 
     if (ain.size() == m_AnalogInput.size())
@@ -761,7 +762,7 @@ void mtsGalilController::GetAnalogInputs(mtsDoubleVec &ain) const
 }
 
 // Disha-encoder
-void mtsGalilController::GetToolZEncoder(mtsInt &toolZencoder) const
+void mtsGalilController::GetToolZEncoder(int &toolZencoder) const
 {
 
     toolZencoder = m_DecPosition;
@@ -891,7 +892,7 @@ void mtsGalilController::SetAbsolutePosition(const prmMaskedDoubleVec &position)
     SendCommandString(buffer);
 }
 
-void mtsGalilController::StopMovement(const mtsBoolVec &mask, double timeout)
+void mtsGalilController::StopMovement(const vctBoolVec &mask, double timeout)
 {
     osaStopwatch timer;
     timer.Reset();
@@ -922,7 +923,7 @@ void mtsGalilController::StopMovement(const mtsBoolVec &mask, double timeout)
 // WaitMotion:  Wait for the robot to stop the current motion
 // waits for the specified axes
 // specified timeout in seconds
-void mtsGalilController::WaitMotion(const mtsBoolVec &mask, double timeout)
+void mtsGalilController::WaitMotion(const vctBoolVec &mask, double timeout)
 {
     osaStopwatch timer;
     timer.Reset();

--- a/code/mtsGalilControllerDR.cpp
+++ b/code/mtsGalilControllerDR.cpp
@@ -1,0 +1,415 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+#include <gclib.h>
+#include <gclibo.h>
+
+#include <cisstCommon/cmnPath.h>
+
+#include <sawGalilController/mtsGalilControllerDR.h>
+
+const size_t GALIL_MAX_AXES = 8;
+
+//****** Axis Data structures in DR packet ******
+
+#pragma pack(push, 1)     // Eliminate structure padding
+
+// AxisDataMin supported by all Galil DMC controllers
+//   - GDataRecord4000 (DMC 4000, 4200, 4103, and 500x0)
+//   - GDataRecord52000 (DMC 52000)
+//   - GDataRecord1806 (DMC 1806)
+//   - GDataRecord2103 (DMC 2103)
+//   - GDataRecord1802 (DMC 1802)
+//   - GDataRecord30000 (DMC 30010)
+struct AxisDataMin {
+    uint16_t status;
+    uint8_t  switches;
+    uint8_t  stop_code;
+    int32_t  ref_pos;
+    int32_t  pos;
+    int32_t  pos_error;
+    int32_t  aux_pos;
+    int32_t  vel;
+    int32_t  torque;
+    uint16_t analog_in;   // reserved for 1802
+};
+
+// AxisDataMax supported by:
+//   - GDataRecord4000 (DMC 4000, 4200, 4103, and 500x0)
+//   - GDataRecord52000 (DMC 52000)
+//   - GDataRecord30000 (DMC 30010)
+struct AxisDataMax : public AxisDataMin {
+    uint8_t  hall;        // reserved for 1806
+    uint8_t  reserved;
+    int32_t  var;         // User-defined (ZA)
+};
+
+#pragma pack(pop)
+
+// Following is information specific to the different Galil DMC controller models.
+// There currently are 6 different DMC model types. We do not support any RIO controllers.
+const size_t NUM_MODELS = 6;
+const size_t ADmin = sizeof(AxisDataMin);
+const size_t ADmax = sizeof(AxisDataMax);
+// The Galil model types (corresponding to the different GDataRecord structs)
+const unsigned int ModelTypes[NUM_MODELS]     = {  4000, 52000,  1806,  2103,  1802, 30000 };
+// Byte offset to the start of the axis data
+const unsigned int AxisDataOffset[NUM_MODELS] = {    82,    82,    78 ,   44,    40,    38 };
+// Size of the axis data
+const size_t AxisDataSize[NUM_MODELS]         = { ADmax, ADmax, ADmin, ADmin, ADmin, ADmax };
+// Whether the first 4 bytes contain header information
+const bool HasHeader[NUM_MODELS]              = {  true,  true, false,  true, false,  true };
+// Byte offset to the sample number
+const unsigned int SampleOffset[NUM_MODELS]   = {     4,     4,     0,     4,     0,     4 };
+
+CMN_IMPLEMENT_SERVICES_DERIVED_ONEARG(mtsGalilControllerDR, mtsTaskContinuous, mtsTaskContinuousConstructorArg)
+
+mtsGalilControllerDR::mtsGalilControllerDR(const std::string &name, unsigned int sizeStateTable, bool newThread) :
+    mtsTaskContinuous(name, sizeStateTable, newThread), mGalil(0)
+{
+    Init();
+}
+
+mtsGalilControllerDR::mtsGalilControllerDR(const mtsTaskContinuousConstructorArg & arg) :
+    mtsTaskContinuous(arg), mGalil(0)
+{
+    Init();
+}
+
+mtsGalilControllerDR::~mtsGalilControllerDR()
+{
+    Close();
+}
+
+void mtsGalilControllerDR::Init(void)
+{
+    mHeader = 0;
+    StateTable.AddData(mHeader, "dr_header");
+    StateTable.AddData(mSampleNum, "sample_num");
+    StateTable.AddData(m_measured_js, "measured_js");
+    StateTable.AddData(m_setpoint_js, "setpoint_js");
+
+    mInterface = AddInterfaceProvided("control");
+    if (mInterface) {
+        // for Status, Warning and Error with mtsMessage
+        mInterface->AddMessageEvents();
+
+        // Standard CRTK interfaces
+        mInterface->AddCommandReadState(this->StateTable, m_measured_js, "measured_js");
+        mInterface->AddCommandReadState(this->StateTable, m_setpoint_js, "setpoint_js");
+        mInterface->AddCommandWrite(&mtsGalilControllerDR::servo_jp, this, "servo_jp");
+        mInterface->AddCommandWrite(&mtsGalilControllerDR::servo_jv, this, "servo_jv");
+
+        mInterface->AddCommandVoid(&mtsGalilControllerDR::EnableMotorPower, this, "EnableMotorPower");
+        mInterface->AddCommandVoid(&mtsGalilControllerDR::DisableMotorPower, this, "DisableMotorPower");
+
+        // Stats
+        mInterface->AddCommandReadState(StateTable, StateTable.PeriodStats, "GetPeriodStatistics");
+
+        // Extra stuff
+        mInterface->AddCommandRead(&mtsGalilControllerDR::GetNumAxes, this, "GetNumAxes");
+        mInterface->AddCommandRead(&mtsGalilControllerDR::GetHeader, this, "GetHeader");
+        mInterface->AddCommandReadState(this->StateTable, mSampleNum, "GetSampleNum");
+        mInterface->AddCommandRead(&mtsGalilControllerDR::GetConnected, this, "GetConnected");
+		mInterface->AddCommandWrite(&mtsGalilControllerDR::SendCommand, this, "SendCommand");
+		mInterface->AddCommandWriteReturn(&mtsGalilControllerDR::SendCommandRet, this, "SendCommandRet");
+    }
+}
+
+void mtsGalilControllerDR::Close()
+{
+
+    if (mGalil) {
+        GClose(mGalil);
+        mGalil = 0;
+    }
+}
+
+void mtsGalilControllerDR::Configure(const std::string& fileName)
+{
+    std::string dmcStartupFile;
+
+    std::ifstream jsonStream;
+    jsonStream.open(fileName.c_str());
+    Json::Value jsonConfig;
+    Json::Reader jsonReader;
+    if (!jsonReader.parse(jsonStream, jsonConfig)) {
+        CMN_LOG_CLASS_INIT_ERROR << "Configure: failed to parse " << fileName << " for Galil config" << std::endl
+                                 << jsonReader.getFormattedErrorMessages();
+        return;
+    }
+
+    const Json::Value jsonVersion = jsonConfig["FileVersion"];
+    if (jsonVersion.empty()) {
+        CMN_LOG_CLASS_INIT_ERROR << "Error: no \"FileVersion\" field in JSON file: " << fileName << std::endl;
+        return;
+    }
+    unsigned int version = jsonVersion.asUInt();
+    if (version != 1) {
+        CMN_LOG_CLASS_INIT_ERROR << "Error: unsupported JSON FileVersion: " << version << std::endl;
+        return;
+    }
+
+    const Json::Value ipAddr = jsonConfig["IP_Address"];
+    if (ipAddr.empty()) {
+        CMN_LOG_CLASS_INIT_ERROR << "Configure: no \"IP_Address\" field in JSON file: " << fileName << std::endl;
+        return;
+    }
+    mDeviceName = ipAddr.asString();
+    CMN_LOG_CLASS_INIT_VERBOSE << "Configure: setting IP address " << mDeviceName << std::endl;
+
+    mDirectMode = jsonConfig.get("Galil_Direct", false).asBool();
+    if (mDirectMode)
+        CMN_LOG_CLASS_INIT_VERBOSE << "Configure: setting Galil direct mode" << std::endl;
+
+    unsigned int modelType = jsonConfig.get("Galil_Model", 4000).asUInt();
+    unsigned int i;
+    for (i = 0; i < NUM_MODELS; i++) {
+        if (modelType == ModelTypes[i]) {
+            mModel = i;
+            break;
+        }
+    }
+    if (i == NUM_MODELS) {
+        CMN_LOG_CLASS_INIT_ERROR << "Configure: invalid Galil model type " << modelType << std::endl;
+        return;
+    }
+    CMN_LOG_CLASS_INIT_VERBOSE << "Configure: setting Galil model to " << modelType
+                               << " (index = " << mModel << ")" << std::endl;
+
+    unsigned int mDR_Period_ms = jsonConfig.get("DR_Period_ms", 2).asUInt();
+    CMN_LOG_CLASS_INIT_VERBOSE << "Configure: setting DR period to " << mDR_Period_ms << " ms" << std::endl;
+
+    // Get axes array
+    const Json::Value axesArray = jsonConfig["Axes"];
+    if (axesArray.empty()) {
+        CMN_LOG_CLASS_INIT_ERROR << "Configure: cannot find \"Axes\" in " << fileName << std::endl;
+        return;
+    }
+
+    // Size of array determines number of axes
+    mNumAxes = axesArray.size();
+    CMN_LOG_CLASS_INIT_VERBOSE << "Configure: found " << mNumAxes << " axes" << std::endl;
+
+    // Now, set the data sizes
+    // We have position, velocity and effort for measured_js
+    m_measured_js.SetSize(mNumAxes);
+    // We have only position for setpoint_js
+    m_setpoint_js.Name().SetSize(mNumAxes);
+    m_setpoint_js.Position().SetSize(mNumAxes);
+
+    mAxisToGalilChannelMap.SetSize(mNumAxes);
+    mEncoderCountsPerUnit.SetSize(mNumAxes);
+
+    for (Json::ArrayIndex i = 0; i < axesArray.size(); i++) {
+        const Json::Value curAxis = axesArray[i];
+        const Json::Value galilIndexJson = curAxis["Galil_Channel"];
+        if (galilIndexJson.empty()) {
+            CMN_LOG_CLASS_INIT_ERROR << "Configure: missing \"Galil_Channel\" for axis " << i << std::endl;
+            return;
+        }
+        if (!galilIndexJson.isNumeric()) {
+            CMN_LOG_CLASS_INIT_ERROR << "Configure: \"Galil_Channel\" for axis " << i
+                                     << " is not a numeric value" << std::endl;
+            return;
+        }
+        unsigned int galilIndex = galilIndexJson.asUInt();
+        if (galilIndex >= GALIL_MAX_AXES) {
+            CMN_LOG_CLASS_INIT_ERROR << "Configure: \"Galil_Channel\" for axis " << i
+                                     << " must be 0-" << (GALIL_MAX_AXES-1) << std::endl;
+            return;
+        }
+        mAxisToGalilChannelMap[i] = galilIndex;
+        char galilChannel = 'A'+galilIndex;
+        m_measured_js.Name()[i].assign(1, galilChannel);
+        m_setpoint_js.Name()[i].assign(1, galilChannel);
+        mEncoderCountsPerUnit[i] = curAxis.get("Encoder_Conversion", 1.0).asDouble();
+    }
+
+    // Galil Startup Program
+    if (jsonConfig.isMember("DMC_Startup_Program")) {
+        dmcStartupFile = jsonConfig["DMC_Startup_Program"].asString();
+    }
+
+    // upload a dmc program file if available
+    if (dmcStartupFile.length() > 0) {
+        if (cmnPath::Exists(dmcStartupFile)) {
+            GProgramUploadFile(mGalil, dmcStartupFile.c_str());
+        }
+        else {
+            CMN_LOG_CLASS_INIT_ERROR << "Configure: Invalid DMC program file \""
+                                     << dmcStartupFile << "\"" << std::endl;
+        }
+    }
+}
+
+void mtsGalilControllerDR::Startup()
+{
+    std::string GalilString = mDeviceName;
+    if (mDirectMode)
+        GalilString.append(" -d");
+    GalilString.append(" -s DR");  // Subscribe to DR records
+    GReturn ret = GOpen(GalilString.c_str(), &mGalil);
+    if (ret != G_NO_ERROR) {
+        CMN_LOG_CLASS_INIT_ERROR << "Galil GOpen: error opening " << mDeviceName
+                                 << ": " << ret << std::endl;
+        return;
+    }
+    ret = GRecordRate(mGalil, mDR_Period_ms);
+    if (ret != G_NO_ERROR) {
+        CMN_LOG_CLASS_INIT_ERROR << "Galil GRecordRate: error " << ret << " setting rate to "
+                                 << mDR_Period_ms << " ms" << std::endl;
+        // Close connection so we do not hang waiting for data
+        Close();
+    }
+}
+
+void mtsGalilControllerDR::Run()
+{
+    GDataRecord gRec;
+
+    // Get the Galil data record (DR) and parse it
+    if (mGalil && (GRecord(mGalil, &gRec, G_DR) == G_NO_ERROR)) {
+        // First 4 bytes are header (for most controllers)
+        if (HasHeader[mModel])
+            mHeader = *reinterpret_cast<uint32_t *>(gRec.byte_array);
+        // Controller sample number
+        mSampleNum = *reinterpret_cast<uint16_t *>(gRec.byte_array + SampleOffset[mModel]);
+        // Get the axis data
+        // Since we currently do not care about the last 3 entries (in AxisDataMax), we
+        // just cast to AxisDataMin and handle the different offsets.
+        for (size_t i = 0; i < mNumAxes; i++) {
+            unsigned int galilAxis = mAxisToGalilChannelMap[i];
+            AxisDataMin *axisPtr = reinterpret_cast<AxisDataMin *>(gRec.byte_array +
+                                                                   AxisDataOffset[mModel] +
+                                                                   galilAxis*AxisDataSize[mModel]);
+            m_measured_js.Position()[i] = mEncoderCountsPerUnit[i] * axisPtr->pos;
+            m_measured_js.Velocity()[i] = mEncoderCountsPerUnit[i] * axisPtr->vel;
+            m_measured_js.Effort()[i] = axisPtr->torque;
+            m_setpoint_js.Position()[i] = mEncoderCountsPerUnit[i] * axisPtr->ref_pos;
+        }
+    }
+
+    // Call any connected components
+    RunEvent();
+
+    ProcessQueuedCommands();
+}
+
+void mtsGalilControllerDR::Cleanup(){
+    Close();
+}
+
+void mtsGalilControllerDR::SendCommand(const std::string &cmdString)
+{
+    if (mGalil) {
+        GReturn ret = GCmd(mGalil, cmdString.c_str());
+        if (ret != G_NO_ERROR) {
+            CMN_LOG_CLASS_RUN_ERROR << "SendCommand: error " << ret << " sending " << cmdString << std::endl;
+        }
+    }
+}
+
+void mtsGalilControllerDR::SendCommandRet(const std::string &cmdString, std::string &retString)
+{
+    if (mGalil) {
+        char buffer[G_SMALL_BUFFER];
+        char *firstChar;
+        GReturn ret = GCmdT(mGalil, cmdString.c_str(), buffer, G_SMALL_BUFFER, &firstChar);
+        if (ret == G_NO_ERROR) {
+            retString.assign(firstChar);
+        }
+        else {
+            retString.clear();
+            CMN_LOG_CLASS_RUN_ERROR << "SendCommandRet: error " << ret << " sending " << cmdString << std::endl;
+        }
+    }
+}
+
+// Enable motor power
+void mtsGalilControllerDR::EnableMotorPower(void)
+{
+    SendCommand("SH");
+}
+
+// Disable motor power
+void mtsGalilControllerDR::DisableMotorPower(void)
+{
+    SendCommand("MO");
+}
+
+void mtsGalilControllerDR::servo_common(const char *cmdName, const char *cmdGalil, const vctDoubleVec &goal)
+{
+    if (!mGalil)
+        return;
+
+    size_t i;
+    size_t goalAxes = goal.size();
+    if (goalAxes != mNumAxes) {
+        mInterface->SendWarning(this->GetName() + ": size mismatch in " + std::string(cmdName));
+        CMN_LOG_CLASS_RUN_WARNING << cmdName << ": size mismatch (num_goals = " << goalAxes
+                                  << ", num_axes = " << mNumAxes << ")" << std::endl;
+    }
+    // Ignore any extra axes
+    if (goalAxes > mNumAxes)
+        goalAxes = mNumAxes;
+
+    char Cmd_buffer[G_SMALL_BUFFER];
+    char BG_buffer[G_SMALL_BUFFER];
+
+    int32_t galilData[GALIL_MAX_AXES];
+    bool galilDataValid[GALIL_MAX_AXES];
+    for (i = 0; i < GALIL_MAX_AXES; i++)
+        galilDataValid[i] = false;
+
+    unsigned int galilIndexMax = 0;
+    for (i = 0; i < goalAxes; i++) {
+        unsigned int galilIndex = mAxisToGalilChannelMap[i];
+        if (galilIndex > galilIndexMax)
+            galilIndexMax = galilIndex;
+        galilData[galilIndex] = static_cast<int32_t>(goal[i]/mEncoderCountsPerUnit[i]);
+        galilDataValid[galilIndex] = true;
+    }
+    strcpy(Cmd_buffer, cmdGalil);
+    strcpy(BG_buffer, "BG ");
+    size_t Cmd_len = strlen(Cmd_buffer);
+    size_t BG_len = 3;
+    for (i = 0; i < galilIndexMax; i++) {
+        if (galilDataValid[i]) {
+            sprintf(Cmd_buffer+Cmd_len, "%ld", galilData[i]);
+            Cmd_len = strlen(Cmd_buffer);
+        }
+        if (--goalAxes > 0) {
+            Cmd_buffer[Cmd_len++] = ',';
+            Cmd_buffer[Cmd_len] = 0;
+        }
+        BG_buffer[BG_len++] = static_cast<char>('A'+i);
+        BG_buffer[BG_len] = 0;
+    }
+    CMN_LOG_CLASS_RUN_VERBOSE << cmdName << ": sending \"" << Cmd_buffer << "\", followed by \""
+                              << BG_buffer << "\" to Galil" << std::endl;
+    SendCommand(Cmd_buffer);
+    SendCommand(BG_buffer);
+}
+
+void mtsGalilControllerDR::servo_jp(const prmPositionJointSet &jtpos)
+{
+    servo_common("servo_jp", "PA ", jtpos.Goal());
+}
+
+void mtsGalilControllerDR::servo_jv(const prmVelocityJointSet &jtvel)
+{
+    servo_common("servo_jv", "JG ", jtvel.Goal());
+}

--- a/code/mtsGalilControllerDR.cpp
+++ b/code/mtsGalilControllerDR.cpp
@@ -223,6 +223,8 @@ void mtsGalilControllerDR::Configure(const std::string& fileName)
 
     mAxisToGalilChannelMap.SetSize(mNumAxes);
     mEncoderCountsPerUnit.SetSize(mNumAxes);
+    mStopCode.SetSize(mNumAxes);
+    mSwitches.SetSize(mNumAxes);
 
     for (Json::ArrayIndex i = 0; i < axesArray.size(); i++) {
         const Json::Value curAxis = axesArray[i];
@@ -320,6 +322,8 @@ void mtsGalilControllerDR::Run()
                 m_measured_js.Velocity()[i] = mEncoderCountsPerUnit[i] * axisPtr->vel;
                 m_measured_js.Effort()[i] = axisPtr->torque;
                 m_setpoint_js.Position()[i] = mEncoderCountsPerUnit[i] * axisPtr->ref_pos;
+                mStopCode[i] = axisPtr->stop_code;    // See Galil SC command
+                mSwitches[i] = axisPtr->switches;     // See Galil TS command
             }
         }
         else {

--- a/code/mtsGalilControllerDR.cpp
+++ b/code/mtsGalilControllerDR.cpp
@@ -240,18 +240,7 @@ void mtsGalilControllerDR::Configure(const std::string& fileName)
 
     // Galil Startup Program
     if (jsonConfig.isMember("DMC_Startup_Program")) {
-        dmcStartupFile = jsonConfig["DMC_Startup_Program"].asString();
-    }
-
-    // upload a dmc program file if available
-    if (dmcStartupFile.length() > 0) {
-        if (cmnPath::Exists(dmcStartupFile)) {
-            GProgramUploadFile(mGalil, dmcStartupFile.c_str());
-        }
-        else {
-            CMN_LOG_CLASS_INIT_ERROR << "Configure: Invalid DMC program file \""
-                                     << dmcStartupFile << "\"" << std::endl;
-        }
+        mDmcFile = jsonConfig["DMC_Startup_Program"].asString();
     }
 }
 
@@ -266,6 +255,17 @@ void mtsGalilControllerDR::Startup()
         CMN_LOG_CLASS_INIT_ERROR << "Galil GOpen: error opening " << mDeviceName
                                  << ": " << ret << std::endl;
         return;
+    }
+
+    // Upload a DMC program file if available
+    if (!mDmcFile.empty()) {
+        if (cmnPath::Exists(mDmcFile)) {
+            GProgramUploadFile(mGalil, mDmcFile.c_str());
+        }
+        else {
+            CMN_LOG_CLASS_INIT_ERROR << "Configure: DMC program file \""
+                                     << mDmcFile << "\" not found" << std::endl;
+        }
     }
     ret = GRecordRate(mGalil, mDR_Period_ms);
     if (ret != G_NO_ERROR) {

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+#
+# --- begin cisst license - do not edit ---
+#
+# This software is provided "as is" under an open source license, with
+# no warranty.  The complete license can be found in license.txt and
+# http://www.cisst.org/cisst/license.txt.
+#
+# --- end cisst license ---
+
+add_subdirectory (ConsoleTest)

--- a/examples/ConsoleTest/CMakeLists.txt
+++ b/examples/ConsoleTest/CMakeLists.txt
@@ -1,0 +1,53 @@
+#
+# (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+#
+# --- begin cisst license - do not edit ---
+#
+# This software is provided "as is" under an open source license, with
+# no warranty.  The complete license can be found in license.txt and
+# http://www.cisst.org/cisst/license.txt.
+#
+# --- end cisst license ---
+
+project (sawGalilConsoleTest)
+
+# List cisst libraries needed
+set (REQUIRED_CISST_LIBRARIES cisstCommon
+                              cisstVector
+                              cisstOSAbstraction
+                              cisstMultiTask
+                              cisstParameterTypes)
+
+# find cisst and make sure the required libraries have been compiled
+find_package (cisst 1.2 COMPONENTS ${REQUIRED_CISST_LIBRARIES})
+
+if (cisst_FOUND_AS_REQUIRED)
+
+  # load cisst configuration
+  include (${CISST_USE_FILE})
+
+  find_package (sawGalilController REQUIRED
+                HINTS ${CMAKE_BINARY_DIR})
+  include_directories (${sawGalilController_INCLUDE_DIR})
+  link_directories (${sawGalilController_LIBRARY_DIR})
+
+  add_executable (sawGalilConsole main.cpp)
+
+  # link with the cisst libraries
+  cisst_target_link_libraries (sawGalilConsole ${REQUIRED_CISST_LIBRARIES})
+
+  # link with sawGalilController library
+  target_link_libraries (sawGalilConsole ${sawGalilController_LIBRARIES})
+
+  set_target_properties (sawGalilConsole PROPERTIES
+    COMPONENT sawGalilController-Examples
+    FOLDER "sawGalilController")
+
+  install (TARGETS sawGalilConsole COMPONENT sawGalilController-Examples
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+
+else (cisst_FOUND_AS_REQUIRED)
+  message ("Information: sawGalilConsole will not be compiled, it requires ${REQUIRED_CISST_LIBRARIES}")
+endif (cisst_FOUND_AS_REQUIRED)

--- a/examples/ConsoleTest/main.cpp
+++ b/examples/ConsoleTest/main.cpp
@@ -123,8 +123,6 @@ public:
         const prmStateJoint *psj = dynamic_cast<const prmStateJoint *>(p);
         if (psj) NumAxes = psj->Position().size();
 #else
-        // Following does not yet work because GetActuatorState is added to
-        // provided interface before sizes are set.
         const mtsGenericObject *p = GetActuatorState.GetArgumentPrototype();
         const prmActuatorState *pas = dynamic_cast<const prmActuatorState *>(p);
         if (pas) NumAxes = pas->Position().size();

--- a/examples/ConsoleTest/main.cpp
+++ b/examples/ConsoleTest/main.cpp
@@ -1,0 +1,161 @@
+/*-*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-   */
+/*ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab:*/
+
+/*
+(C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+#include <cisstCommon/cmnLogger.h>
+#include <cisstCommon/cmnKbHit.h>
+#include <cisstCommon/cmnGetChar.h>
+#include <cisstCommon/cmnConstants.h>
+#include <cisstOSAbstraction/osaSleep.h>
+#include <cisstMultiTask/mtsManagerLocal.h>
+#include <cisstMultiTask/mtsTaskContinuous.h>
+#include <cisstMultiTask/mtsInterfaceRequired.h>
+#include <sawGalilController/mtsGalilController.h>
+
+class GalilClient : public mtsTaskMain {
+
+private:
+    prmActuatorState m_ActuatorState;
+
+    mtsFunctionRead GetActuatorState;
+    mtsFunctionWrite SendCommand;
+
+public:
+
+    GalilClient() : mtsTaskMain("GalilClient")
+    {
+        mtsInterfaceRequired *req = AddInterfaceRequired("Input", MTS_OPTIONAL);
+        if (req) {
+            req->AddFunction("GetActuatorState", GetActuatorState);
+            req->AddFunction("SendCommand", SendCommand);
+        }
+    }
+
+    void Configure(const std::string&) {}
+
+    void PrintHelp()
+    {
+        std::cout << "Available commands:" << std::endl
+                  << "  c: send command" << std::endl
+                  << "  h: display help information" << std::endl
+                  << "  q: quit" << std::endl;
+    }
+
+    void Startup()
+    {
+        PrintHelp();
+    }
+
+    void Run() {
+
+        ProcessQueuedEvents();
+
+        GetActuatorState(m_ActuatorState);
+
+        char c = 0;
+        if (cmnKbHit()) {
+            c = cmnGetChar();
+            switch (c) {
+
+            case 'c':
+                {
+                std::string cmdString;
+                std::cout << std::endl << "Enter command: ";
+                std::cin >> cmdString;
+                SendCommand(cmdString);
+                }
+                break;
+                
+            case 'h':
+                std::cout << std::endl;
+                PrintHelp();
+                break;
+
+            case 'q':   // quit program
+                std::cout << "Exiting.. " << std::endl;
+                this->Kill();
+                break;
+            }
+        }
+
+        mtsDoubleVec pos;
+        m_ActuatorState.GetPosition(pos);
+        printf("JOINT POS:   [");
+        for (size_t i = 0; i < pos.size(); i++)
+            printf(" %7.2lf ", pos[i]);
+        printf("]\r");
+
+        osaSleep(0.01);  // to avoid taking too much CPU time
+    }
+
+    void Cleanup() {}
+
+};
+
+int main(int argc, char **argv)
+{
+    cmnLogger::SetMask(CMN_LOG_ALLOW_ALL);
+    cmnLogger::SetMaskDefaultLog(CMN_LOG_ALLOW_ALL);
+    cmnLogger::SetMaskFunction(CMN_LOG_ALLOW_ALL);
+    cmnLogger::AddChannel(std::cout, CMN_LOG_ALLOW_ERRORS_AND_WARNINGS);
+
+    double periodSec = 0.005;
+    if (argc < 2) {
+        std::cout << "Syntax: sawGalilConsole <config> [<period>]" << std::endl;
+        std::cout << "        <config>      Configuration file (JSON format)" << std::endl;
+        std::cout << "        [<period>]    Sampling period, sec (default " << periodSec << ")" << std::endl;
+        return 0;
+    }
+    if (argc > 2) {
+        if (sscanf(argv[2], "%lf", &periodSec) != 1) {
+            std::cout << "Failed to parse period " << argv[2] << std::endl;
+            return -1;
+        }
+    }
+        
+    std::cout << "Starting mtsGalilController with period " << periodSec << " sec" << std::endl;
+    mtsGalilController *galilServer;
+    galilServer = new mtsGalilController("galilServer", periodSec);
+    galilServer->Configure(argv[1]);
+
+    mtsComponentManager * componentManager = mtsComponentManager::GetInstance();
+    componentManager->AddComponent(galilServer);
+
+    GalilClient client;
+    componentManager->AddComponent(&client);
+
+    if (!componentManager->Connect(client.GetName(), "Input", galilServer->GetName(), "control")) {
+        std::cout << "Failed to connect: "
+            << client.GetName() << "::Input to "
+            << galilServer->GetName() << "::control" << std::endl;
+        delete galilServer;
+        return -1;
+    }
+
+    componentManager->CreateAll();
+    componentManager->StartAll();
+
+    // Main thread passed to client task
+
+    galilServer->Kill();
+    componentManager->WaitForStateAll(mtsComponentState::FINISHED, 2.0 * cmn_s);
+
+    componentManager->Cleanup();
+
+    // stop all logs
+    cmnLogger::SetMask(CMN_LOG_ALLOW_NONE);
+    delete galilServer;
+
+    return 0;
+}

--- a/include/sawGalilController/mtsGalilController.h
+++ b/include/sawGalilController/mtsGalilController.h
@@ -1,18 +1,33 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
 #ifndef _mtsGalilContoller_h
 #define _mtsGalilContoller_h
 
 #include <memory>
 
-#include <gclib.h>
-#include <gclibo.h>
-
 #include <cisstParameterTypes/prmActuatorState.h>
 #include <cisstParameterTypes/prmMaskedVector.h>
-#include <cisstMultiTask.h>
+#include <cisstMultiTask/mtsTaskPeriodic.h>
+
+// Always include last
+#include <sawGalilController/sawGalilControllerExport.h>
 
 class CISST_EXPORT mtsGalilController : public mtsTaskPeriodic
 {
-    CMN_DECLARE_SERVICES(CMN_NO_DYNAMIC_CREATION, CMN_LOG_LOD_RUN_ERROR);
+    CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_LOD_RUN_ERROR)
 
 public:
     mtsGalilController(const std::string &componentName, double period_secs);
@@ -198,7 +213,6 @@ protected:
     // Disha-encoder
     std::vector<std::string> DI;
 
-
     // Component fields
     mtsStateTable m_StateTable;
     prmActuatorState m_ActuatorState;
@@ -228,19 +242,19 @@ private:
     // galil controller class handle
     GCon         m_Galil;
     mtsStdString m_DeviceName;
-    
+
     // internal variable used to calculate velocity times.
     double            m_ServoLoopTime;
     double            m_TMVelocityMultiplier;
     GDataRecord       m_dataRecord;
-    
+
     // internal is moving state
     vctBoolVec m_SoftRevLimitHit;
     vctBoolVec m_SoftFwdLimitHit;
     size_t     m_NumberEncoderPins;
 
-}; // class: mtsGalilControllerSensorFeedback_Templated
+};
 
-CMN_DECLARE_SERVICES_INSTANTIATION(mtsGalilController);
+CMN_DECLARE_SERVICES_INSTANTIATION(mtsGalilController)
 
 #endif

--- a/include/sawGalilController/mtsGalilController.h
+++ b/include/sawGalilController/mtsGalilController.h
@@ -16,7 +16,8 @@ http://www.cisst.org/cisst/license.txt.
 #ifndef _mtsGalilContoller_h
 #define _mtsGalilContoller_h
 
-#include <memory>
+#include <string>
+#include <vector>
 
 #include <cisstParameterTypes/prmActuatorState.h>
 #include <cisstParameterTypes/prmMaskedVector.h>
@@ -220,7 +221,7 @@ protected:
     float m_timeout = 60.0 * cmn_s;
 
 private:
-    static inline void CheckErrorGCommand(GReturn rc) throw(GReturn) { if (rc != G_NO_ERROR) throw rc; } 
+    static inline void CheckErrorGCommand(GReturn rc) { if (rc != G_NO_ERROR) throw rc; }
     static GCStringOut BufferToGCStringOut(char* buffer, unsigned int buffer_size);
 
     void ConnectToGalilController(const std::string& deviceName);

--- a/include/sawGalilController/mtsGalilController.h
+++ b/include/sawGalilController/mtsGalilController.h
@@ -227,10 +227,10 @@ private:
 
     void ConnectToGalilController(const std::string& deviceName);
 
-    //////-----	Motion commands   -----//////
+    //////----- Motion commands   -----//////
     //  (all positions are in COUNTS and are relative to the ACTUATOR HOME position).
     // All the mtsVectors are going to be the size of the MAX_
-    vctBoolVec	 m_IsHomed;  // TRUE if actuator IsHomed
+    vctBoolVec   m_IsHomed;  // TRUE if actuator IsHomed
     vctDoubleVec m_AnalogInput;
 
     // Disha-encoder

--- a/include/sawGalilController/mtsGalilController.h
+++ b/include/sawGalilController/mtsGalilController.h
@@ -19,6 +19,9 @@ http://www.cisst.org/cisst/license.txt.
 #include <string>
 #include <vector>
 
+#include <gclib.h>
+#include <gclibo.h>
+
 #include <cisstVector/vctDynamicVectorTypes.h>
 #include <cisstParameterTypes/prmActuatorState.h>
 #include <cisstParameterTypes/prmMaskedVector.h>

--- a/include/sawGalilController/mtsGalilController.h
+++ b/include/sawGalilController/mtsGalilController.h
@@ -19,6 +19,7 @@ http://www.cisst.org/cisst/license.txt.
 #include <string>
 #include <vector>
 
+#include <cisstVector/vctDynamicVectorTypes.h>
 #include <cisstParameterTypes/prmActuatorState.h>
 #include <cisstParameterTypes/prmMaskedVector.h>
 #include <cisstMultiTask/mtsTaskPeriodic.h>
@@ -43,10 +44,10 @@ public:
     void Cleanup(void) override;
 
     // Galil Controller Functions
-    void SetTimeout(const mtsDouble &timeout, mtsBool &success);
+    void SetTimeout(const double &timeout, bool &success);
 
-    inline void WaitMotion(const mtsBoolVec &mask) { WaitMotion(mask, m_timeout); }
-    inline void StopMovement(const mtsBoolVec &mask) { StopMovement(mask, m_timeout); }
+    inline void WaitMotion(const vctBoolVec &mask) { WaitMotion(mask, m_timeout); }
+    inline void StopMovement(const vctBoolVec &mask) { StopMovement(mask, m_timeout); }
 
     // Initialize (e.g., establish communications with the controller)
     // and configure the robot.  Note that a configuration file name could
@@ -58,18 +59,18 @@ public:
     void DisableAllMotorPower();
 
     // specify the axes.
-    void EnableMotorPower(const mtsBoolVec &mask);
+    void EnableMotorPower(const vctBoolVec &mask);
     // turn power off to the motors, run stopmotion command first just in case
     // otherwise it is not possible to turn off motors when running?
-    void DisableMotorPower(const mtsBoolVec &mask);
+    void DisableMotorPower(const vctBoolVec &mask);
 
     // Stop robot motion (do not disable motor power)
     void StopMotionAll();
-    void StopMotion(const mtsBoolVec &mask);
+    void StopMotion(const vctBoolVec &mask);
 
     // the mask is used as command mask, where bool=true homes that axes in the vector
-    void Home(const mtsBoolVec &mask);
-    void UnHome(const mtsBoolVec &mask);
+    void Home(const vctBoolVec &mask);
+    void UnHome(const vctBoolVec &mask);
 
     // Abort robot command
     void AbortProgram();
@@ -87,9 +88,9 @@ public:
     //     in counts/sec**2
     void GetActuatorState(prmActuatorState &state);
 
-    void GetAnalogInputs(mtsDoubleVec &ain) const;
+    void GetAnalogInputs(vctDoubleVec &ain) const;
     // Disha-encoder
-    void GetToolZEncoder(mtsInt &toolZencoder) const;
+    void GetToolZEncoder(int &toolZencoder) const;
 
     // The expected  values are in counts.
     // Set the desired motion goals.
@@ -113,13 +114,13 @@ public:
 
     //*** Other functions:
     // Wait for all motion to be complete, with a timeout in seconds.
-    void StopMovement(const mtsBoolVec &mask, double timeout = 60);
+    void StopMovement(const vctBoolVec &mask, double timeout = 60);
     // Wait for all motion to be complete, with a timeout in seconds.
-    void WaitMotion(const mtsBoolVec &mask, double timeout = 60);
+    void WaitMotion(const vctBoolVec &mask, double timeout = 60);
 
     //*** Low-level functions that have been made public for use with the IRE:
     // Send command to Galil controller and return pointer to response buffer.
-    inline void SendCommand(const mtsStdString& cmd) { SendCommandString(cmd.Data); }
+    inline void SendCommand(const std::string& cmd) { SendCommandString(cmd); }
     std::string SendCommandString(const std::string& cmd);
     /* Sends a command knowing that the return value will be a int */
     int         SendCommandInt(const std::string& cmd);
@@ -136,8 +137,8 @@ public:
     };
 
     // change the pid parameters by loading different
-    void GetMotionMode(mtsUInt &mode) const { mode = m_MotionMode; }
-    void SetMotionMode(const mtsUInt &mode) { m_MotionMode = mode; }
+    void GetMotionMode(unsigned int &mode) const { mode = m_MotionMode; }
+    void SetMotionMode(const unsigned int &mode) { m_MotionMode = mode; }
 
     // Method to record values via QR/DR packets
     enum DataRecordMethod
@@ -147,8 +148,8 @@ public:
     };
     GDataRecord RecordData(const DataRecordMethod &method = DataRecordMethod::QR);
 
-    mtsDoubleVec GetEncoderCountConversionFactors() const { return m_EncoderCountsPerUnit; }
-    void SetEncoderCountConversionFactors(const mtsDoubleVec &conversionFactors)
+    vctDoubleVec GetEncoderCountConversionFactors() const { return m_EncoderCountsPerUnit; }
+    void SetEncoderCountConversionFactors(const vctDoubleVec &conversionFactors)
     {
         assert(conversionFactors.size() == m_EncoderCountsPerUnit.size());
         m_EncoderCountsPerUnit = conversionFactors;
@@ -242,7 +243,7 @@ private:
 
     // galil controller class handle
     GCon         m_Galil;
-    mtsStdString m_DeviceName;
+    std::string  m_DeviceName;
 
     // internal variable used to calculate velocity times.
     double            m_ServoLoopTime;

--- a/include/sawGalilController/mtsGalilController.h
+++ b/include/sawGalilController/mtsGalilController.h
@@ -229,7 +229,6 @@ protected:
 
 private:
     static inline void CheckErrorGCommand(GReturn rc) { if (rc != G_NO_ERROR) throw rc; }
-    static GCStringOut BufferToGCStringOut(char* buffer, unsigned int buffer_size);
 
     void ConnectToGalilController(const std::string& deviceName);
 
@@ -250,6 +249,9 @@ private:
     // galil controller class handle
     GCon         m_Galil;
     std::string  m_DeviceName;
+
+    // DMC program to download to Galil on startup
+    std::string   mDmcFile;
 
     // internal variable used to calculate velocity times.
     double            m_ServoLoopTime;

--- a/include/sawGalilController/mtsGalilController.h
+++ b/include/sawGalilController/mtsGalilController.h
@@ -47,6 +47,8 @@ public:
     void Cleanup(void) override;
 
     // Galil Controller Functions
+    void GetConnected(bool &val) const { val = (m_Galil != 0); }
+
     void SetTimeout(const double &timeout, bool &success);
 
     inline void WaitMotion(const vctBoolVec &mask) { WaitMotion(mask, m_timeout); }
@@ -124,6 +126,7 @@ public:
     //*** Low-level functions that have been made public for use with the IRE:
     // Send command to Galil controller and return pointer to response buffer.
     inline void SendCommand(const std::string& cmd) { SendCommandString(cmd); }
+    inline void SendCommandRet(const std::string& cmd, std::string &ret) { ret = SendCommandString(cmd); }
     std::string SendCommandString(const std::string& cmd);
     /* Sends a command knowing that the return value will be a int */
     int         SendCommandInt(const std::string& cmd);

--- a/include/sawGalilController/mtsGalilControllerDR.h
+++ b/include/sawGalilController/mtsGalilControllerDR.h
@@ -43,7 +43,7 @@ http://www.cisst.org/cisst/license.txt.
 
 class CISST_EXPORT mtsGalilControllerDR : public mtsTaskContinuous
 {
-    CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_LOD_RUN_ERROR);
+    CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_LOD_RUN_ERROR)
 
     void         *mGalil;          // Gcon
     std::string   mDeviceName;     // IP address
@@ -62,7 +62,7 @@ class CISST_EXPORT mtsGalilControllerDR : public mtsTaskContinuous
 
  public:
 
-    mtsGalilControllerDR(const std::string &name, unsigned int sizeStateTable, bool newThread);
+    mtsGalilControllerDR(const std::string &name, unsigned int sizeStateTable = 1024, bool newThread = true);
     mtsGalilControllerDR(const mtsTaskContinuousConstructorArg &arg);
 
     ~mtsGalilControllerDR();
@@ -77,6 +77,8 @@ protected:
 
     void Init();
     void Close();
+
+    void SetupInterfaces();
 
     void GetNumAxes(unsigned int &numAxes) const { numAxes = mNumAxes; }
     void GetHeader(uint32_t &header) const { header = mHeader; }

--- a/include/sawGalilController/mtsGalilControllerDR.h
+++ b/include/sawGalilController/mtsGalilControllerDR.h
@@ -50,6 +50,7 @@ class CISST_EXPORT mtsGalilControllerDR : public mtsTaskContinuous
     bool          mDirectMode;     // Direct connection (not using gcaps)
     unsigned int  mDR_Period_ms;   // DR period, in milliseconds
     unsigned int  mModel;          // Galil model (see list of supported models above)
+    std::string   mDmcFile;        // DMC program to download to Galil on startup
     unsigned int  mNumAxes;        // Number of axes
     uint32_t      mHeader;         // Header bytes in DR packet
     uint16_t      mSampleNum;      // Sample number from controller

--- a/include/sawGalilController/mtsGalilControllerDR.h
+++ b/include/sawGalilController/mtsGalilControllerDR.h
@@ -58,6 +58,8 @@ class CISST_EXPORT mtsGalilControllerDR : public mtsTaskContinuous
     prmStateJoint m_setpoint_js;   // Setpoint joint state (CRTK)
     vctUIntVec    mAxisToGalilChannelMap;   // Map from axis index to Galil channel
     vctDoubleVec  mEncoderCountsPerUnit;    // Encoder conversion factors
+    vctUCharVec   mStopCode;                // Axis stop code (see Galil SC command)
+    vctUCharVec   mSwitches;                // Axis switches (see Galil TS command)
     mtsInterfaceProvided *mInterface;       // Provided interface
 
  public:

--- a/include/sawGalilController/mtsGalilControllerDR.h
+++ b/include/sawGalilController/mtsGalilControllerDR.h
@@ -1,0 +1,104 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+
+  This component provides an interface to a Galil DMC controller, using the DR
+  (DataRecord) approach, where the Galil controller periodically sends a data
+  record. The format of the data record varies based on Galil DMC model type,
+  which can be specified (as "Galil_Model") in the JSON configuration file.
+  Valid values of "Galil_Model" (which is an unsigned integer) are:
+
+      4000   for DMC 4000, 4200, 4103, and 500x0 (default)
+     52000   for DMC 52000
+      1806   for DMC 1806
+      2103   for DMC 2103
+      1802   for DMC 1802
+     30000   for DMC 30010
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+#ifndef _mtsGalilContollerDR_h
+#define _mtsGalilContollerDR_h
+
+#include <string>
+
+#include <cisstVector/vctDynamicVectorTypes.h>
+#include <cisstMultiTask/mtsTaskContinuous.h>
+#include <cisstMultiTask/mtsInterfaceProvided.h>
+#include <cisstParameterTypes/prmStateJoint.h>
+#include <cisstParameterTypes/prmPositionJointSet.h>
+#include <cisstParameterTypes/prmVelocityJointSet.h>
+
+// Always include last
+#include <sawGalilController/sawGalilControllerExport.h>
+
+class CISST_EXPORT mtsGalilControllerDR : public mtsTaskContinuous
+{
+    CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_LOD_RUN_ERROR);
+
+    void         *mGalil;          // Gcon
+    std::string   mDeviceName;     // IP address
+    bool          mDirectMode;     // Direct connection (not using gcaps)
+    unsigned int  mDR_Period_ms;   // DR period, in milliseconds
+    unsigned int  mModel;          // Galil model (see list of supported models above)
+    unsigned int  mNumAxes;        // Number of axes
+    uint32_t      mHeader;         // Header bytes in DR packet
+    uint16_t      mSampleNum;      // Sample number from controller
+    prmStateJoint m_measured_js;   // Measured joint state (CRTK)
+    prmStateJoint m_setpoint_js;   // Setpoint joint state (CRTK)
+    vctUIntVec    mAxisToGalilChannelMap;   // Map from axis index to Galil channel
+    vctDoubleVec  mEncoderCountsPerUnit;    // Encoder conversion factors
+    mtsInterfaceProvided *mInterface;       // Provided interface
+
+ public:
+
+    mtsGalilControllerDR(const std::string &name, unsigned int sizeStateTable, bool newThread);
+    mtsGalilControllerDR(const mtsTaskContinuousConstructorArg &arg);
+
+    ~mtsGalilControllerDR();
+
+    // cisstMultiTask functions
+    void Configure(const std::string &fileName) override;
+    void Startup(void) override;
+    void Run(void) override;
+    void Cleanup(void) override;
+
+protected:
+
+    void Init();
+    void Close();
+
+    void GetNumAxes(unsigned int &numAxes) const { numAxes = mNumAxes; }
+    void GetHeader(uint32_t &header) const { header = mHeader; }
+    void GetSampleNum(unsigned int &sampleNum) const { sampleNum = mSampleNum; }
+    void GetConnected(bool &val) const { val = (mGalil != 0); }
+
+    void SendCommand(const std::string& cmdString);
+    void SendCommandRet(const std::string& cmdString, std::string &retString);
+
+    // Enable motor power
+    void EnableMotorPower(void);
+    // Disable motor power
+    void DisableMotorPower(void);
+
+    // Called by servo_jp and servo_jv
+    void servo_common(const char *cmdName, const char *cmdGalil, const vctDoubleVec &goal);
+
+    // Move joint to specified position
+    void servo_jp(const prmPositionJointSet &jtpos);
+    // Move joint at specified velocity
+    void servo_jv(const prmVelocityJointSet &jtvel);
+};
+
+CMN_DECLARE_SERVICES_INSTANTIATION(mtsGalilControllerDR)
+
+#endif

--- a/include/sawGalilController/sawGalilControllerExport.h
+++ b/include/sawGalilController/sawGalilControllerExport.h
@@ -1,0 +1,25 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-    */
+/* ex: set filetype=cpp softtabstop=4 shiftwidth=4 tabstop=4 cindent expandtab: */
+
+/*
+  (C) Copyright 2024 Johns Hopkins University (JHU), All Rights Reserved.
+
+--- begin cisst license - do not edit ---
+
+This software is provided "as is" under an open source license, with
+no warranty.  The complete license can be found in license.txt and
+http://www.cisst.org/cisst/license.txt.
+
+--- end cisst license ---
+*/
+
+// check if this module is built as a DLL
+#ifdef sawGalilController_EXPORTS
+#define CISST_THIS_LIBRARY_AS_DLL
+#endif
+
+// include common defines
+#include <cisstCommon/cmnExportMacros.h>
+
+// avoid impact on other modules
+#undef CISST_THIS_LIBRARY_AS_DLL

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <package>
-  <name>mts_galil_controller</name>
+  <name>sawGalilController</name>
   <version>2.0.0</version>
   <description>
   mtsGalilController

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,13 +1,15 @@
 cmake_minimum_required (VERSION 3.10)
-project (mts_galil_controller_config)
+project (sawGalilController_config)
 
-find_package (catkin QUIET)
-if (catkin_FOUND)
-    catkin_package()
+if (NOT WIN32)
+    find_package (catkin QUIET)
+    if (catkin_FOUND)
+        catkin_package()
+    endif ()
 endif ()
 
 install (
-    DIRECTORY "${mts_galil_controller_SOURCE_DIR}"
+    DIRECTORY "${sawGalilController_SOURCE_DIR}"
     DESTINATION share/mtsGalilController
     COMPONENT mtsGalilController-Share
     PATTERN "CMakeLists.txt" EXCLUDE

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required (VERSION 3.10)
 project (sawGalilController_config)
 
-if (NOT WIN32)
-    find_package (catkin QUIET)
-    if (catkin_FOUND)
-        catkin_package()
-    endif ()
+find_package (catkin QUIET)
+if (catkin_FOUND)
+    catkin_package()
 endif ()
 
 install (

--- a/share/package.xml
+++ b/share/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package>
-  <name>mts_galil_controller_config</name>
+  <name>sawGalilController_config</name>
   <version>2.2.1</version>
   <description>mtsGalilController config files</description>
 


### PR DESCRIPTION
Key points:
1. Lots of CMake changes, including adding Findgclib.cmake; more changes needed
2. Followed standard SAW naming convention -- project/library is called sawGalilController, whereas files are mtsGalilController. The name is important when using CISST_EXPORT because sawGalilControllerExport.h needs to know the library name.
3. Changed "mts" data types, such as mtsBoolVec, to their corresponding "standard" types, such as vctBoolVec.
4. Better to catch exceptions using a const reference, rather than by value (gcc actually gives a warning about this)
5. Added RunEvent to Run method (for cisstMultitask ExecOut/ExecIn feature); removed call to ProcessQueuedEvents (not needed) and added call to ProcessQueuedCommands (had been commented out)
6. Commented out delete of provided interface -- this was wrong
7. Avoid including header files such as <cisstMultitask.h> and <cisstOSAbstraction.h>

